### PR TITLE
Switch GETs endpoints to use query params

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -32,13 +32,13 @@ def create_api(name, application_layer=None):
     
     @server.route('/plant/data', methods=['GET'])
     def get_plant_data():
-        plant_id = request.json['plant_id']
+        plant_id = request.args.get('plant_id')
         return jsonify(application_layer.plant_data(plant_id))
     
     @server.route('/plant/image', methods=['GET'])
     def get_plant_item():
-        plant_id = request.json['plant_id']
-        image_name = request.json['image_name']
+        plant_id = request.args.get('plant_id')
+        image_name = request.args.get('image_name')
         (image_data, mimetype) = application_layer.get_image(plant_id, image_name)
         if image_data:
             return send_file(image_data, mimetype=mimetype)

--- a/app/application.py
+++ b/app/application.py
@@ -50,7 +50,7 @@ class Application(ApplicationInterface):
     
     def record_plant(self, plant_id, status):
         with open(self.plants_file, 'a') as fs:
-            fs.write(f"{plant_id},status,{plant_id}.jpeg,{plant_id}.png\n")
+            fs.write(f"{plant_id},{status},{plant_id}.jpeg,{plant_id}_segmentation.jpeg\n")
     
     def plant_status(self, plant_id):
         if plant_id in self._plants:
@@ -71,7 +71,7 @@ class Application(ApplicationInterface):
     def get_image(self, plant_id, image_name):
         # TODO: This needs a custom error message
         try:
-            image_file_path = os.path.join(self.image_folder, self._plants[plant_id][image_name])
+            image_file_path = os.path.join(self.image_folder, self._plants[plant_id][image_name].rstrip())
             return open(image_file_path, 'rb'), "image/png" if ("png" in image_file_path) else "image/jpeg"
         except:
             return None, None

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -113,25 +113,23 @@ def test_plant_submission_no_image(client):
 def test_plant_status_valid(client):
     # Given
     plant_id = 'test_guid'
-    header = {'content-type': 'application/json'}
     query_string = {'plant_id': plant_id}
 
     mock_application_layer.clear_plants()
     mock_application_layer.create_plant(plant_id, status="test_status")
     
     # When
-    response = client.get("/plant/status", headers=header, query_string=query_string)
+    response = client.get("/plant/status", query_string=query_string)
     
     # Then
     assert response.json["status"] == "test_status"
 
 def test_plant_status_bad(client):
     # Given
-    header = {'content-type': 'application/json'}
     json = {'plant_id': 'not real id'}
     
     # When
-    response = client.get("/plant/status", headers=header, json=json)
+    response = client.get("/plant/status", json=json)
     
     # Then
     assert response.json["status"] == "plant_not_found"
@@ -139,28 +137,26 @@ def test_plant_status_bad(client):
 def test_plant_data_valid(client):
     # Given
     plant_id = 'test_guid'
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': plant_id}
+    query_string = {'plant_id': plant_id}
 
     mock_application_layer.clear_plants()
     mock_application_layer.create_plant(plant_id, status="complete")
     
     # When
-    response = client.get("/plant/data", headers=header, json=json)
+    response = client.get("/plant/data", query_string=query_string)
     
     # Then
     assert response.json == {"id": plant_id, "status": "complete", "image": f"{plant_id}.jpeg"}
 
 def test_plant_data_bad(client):
     # Given
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': 'not real id'}
+    query_string = {'plant_id': 'not real id'}
 
     mock_application_layer.clear_plants()
     mock_application_layer.create_plant('test_guid', status="complete")
     
     # When
-    response = client.get("/plant/data", headers=header, json=json)
+    response = client.get("/plant/data", query_string=query_string)
     
     # Then
     assert response.json == {"id": "", "status": "", "image": ""}
@@ -168,11 +164,10 @@ def test_plant_data_bad(client):
 def test_plant_get_image_valid_image(client):
     # Given
     plant_id = 'test_guid'
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': plant_id, 'image_name': 'image'}
+    query_string = {'plant_id': plant_id, 'image_name': 'image'}
     
     # When
-    response = client.get("/plant/image", headers=header, json=json)
+    response = client.get("/plant/image", query_string=query_string)
     
     # Then
     assert response.status_code == 200
@@ -182,11 +177,10 @@ def test_plant_get_image_valid_image(client):
 def test_plant_get_image_valid_segmentation(client):
     # Given
     plant_id = 'test_guid'
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': plant_id, 'image_name': 'segmentation'}
+    query_string = {'plant_id': plant_id, 'image_name': 'segmentation'}
     
     # When
-    response = client.get("/plant/image", headers=header, json=json)
+    response = client.get("/plant/image", query_string=query_string)
     
     # Then
     assert response.status_code == 200
@@ -196,11 +190,10 @@ def test_plant_get_image_valid_segmentation(client):
 def test_plant_handles_bad_image_name_grab(client):
     # Given
     plant_id = 'test_guid'
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': plant_id, 'image_name': 'image_not_found'}
+    query_string = {'plant_id': plant_id, 'image_name': 'image_not_found'}
     
     # When
-    response = client.get("/plant/image", headers=header, json=json)
+    response = client.get("/plant/image", query_string=query_string)
     
     # Then
     assert response.status_code == 400
@@ -208,11 +201,10 @@ def test_plant_handles_bad_image_name_grab(client):
 def test_plant_handles_bad_guid(client):
     # Given
     plant_id = 'bad_test_guid'
-    header = {'content-type': 'application/json'}
-    json = {'plant_id': plant_id, 'image_name': 'image_not_found'}
+    query_string = {'plant_id': plant_id, 'image_name': 'image_not_found'}
     
     # When
-    response = client.get("/plant/image", headers=header, json=json)
+    response = client.get("/plant/image", query_string=query_string)
     
     # Then
     assert response.status_code == 400


### PR DESCRIPTION
Before this commit, we were using json bodies to send request information. The Flutter http API does not support json bodies in the request. The use of a body in GET request is also non-standard. We have switched over to using query parameters in the URL to send request data. 
